### PR TITLE
Add missing approver

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ For more information about the maintainer role, see the
 These are the members of [@open-telemetry/docs-approvers]:
 
 - [Michael Hausenblas](https://github.com/mhausenblas), Amazon
+- [Ted Young](https://github.com/tedsuo), Grafana Labs
 
 For more information about the approver role, see the
 [community repository](https://github.com/open-telemetry/community/blob/main/community-membership.md#approver).


### PR DESCRIPTION
Noticed this while running to validation between README files and GitHub team memberships